### PR TITLE
Removing state pollution in `date_rex` in jsonextra

### DIFF
--- a/jsonextra/json_extra.py
+++ b/jsonextra/json_extra.py
@@ -22,6 +22,10 @@ def disable_rex(rex):
     globals()[rex] = None
 
 
+def enable_date_rex():
+    globals()["date_rex"] = re.compile(r'^\d{4}\-[01]\d\-[0-3]\d$')
+
+
 class ExtraEncoder(json.JSONEncoder):
 
     @staticmethod

--- a/jsonextra/json_extra.py
+++ b/jsonextra/json_extra.py
@@ -15,15 +15,22 @@ bytes_rex = re.compile(BYTES_PREFIX + r'([\w\d\+/]*?\={,2}?)$', re.DOTALL)
 
 _all_rex = ['uuid_rex', 'datetime_rex', 'date_rex', 'time_rex', 'bytes_rex']
 
+class regex_manager():
+    regex = [re.compile(r'^[0-9a-f]{8}\-?[0-9a-f]{4}\-?4[0-9a-f]{3}\-?[89ab][0-9a-f]{3}\-?[0-9a-f]{12}$', re.I),
+             re.compile(r'^\d{4}\-[01]\d\-[0-3]\d[\sT][0-2]\d\:[0-5]\d\:[0-5]\d'),
+             re.compile(r'^\d{4}\-[01]\d\-[0-3]\d$'),
+             re.compile(r'^[0-2]\d\:[0-5]\d:[0-5]\d\.?\d{,6}?$'),
+             re.compile(BYTES_PREFIX + r'([\w\d\+/]*?\={,2}?)$', re.DOTALL)]
 
-def disable_rex(rex):
-    """Disables a regulax expresseion for matching"""
-    assert rex in _all_rex, f'Cannot disable rex which is not allowed! Available: {_all_rex}'
-    globals()[rex] = None
+    index = {"uuid_rex": 0, "datetime_rex": 1, "date_rex": 2, "time_rex": 3, "bytes_rex": 4}
 
+    def enable_rex(self, rex):
+        assert rex in _all_rex, f'Cannot disable rex which is not allowed! Available: {_all_rex}'
+        globals()[rex] = self.regex[self.index[rex]]
 
-def enable_date_rex():
-    globals()["date_rex"] = re.compile(r'^\d{4}\-[01]\d\-[0-3]\d$')
+    def disable_rex(self, rex):
+        assert rex in _all_rex, f'Cannot disable rex which is not allowed! Available: {_all_rex}'
+        globals()[rex] = None
 
 
 class ExtraEncoder(json.JSONEncoder):

--- a/tests/test_jsonextra.py
+++ b/tests/test_jsonextra.py
@@ -160,6 +160,6 @@ def test_random_bytes():
 
 def test_disable_rex():
     assert jsonextra.loads('{"x": "1991-02-16"}') == {'x': datetime.date(1991, 2, 16)}
-    jsonextra.disable_rex('date_rex')
+    jsonextra.regex_manager().disable_rex('date_rex')
     assert jsonextra.loads('{"x": "1991-02-16"}') == {'x': '1991-02-16'}
-    jsonextra.enable_date_rex()
+    jsonextra.regex_manager().enable_rex('date_rex')

--- a/tests/test_jsonextra.py
+++ b/tests/test_jsonextra.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 import io
 import uuid
@@ -160,3 +162,4 @@ def test_disable_rex():
     assert jsonextra.loads('{"x": "1991-02-16"}') == {'x': datetime.date(1991, 2, 16)}
     jsonextra.disable_rex('date_rex')
     assert jsonextra.loads('{"x": "1991-02-16"}') == {'x': '1991-02-16'}
+    jsonextra.enable_date_rex()


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_disable_rex` by removing state pollution in `date_rex` in jsonextra by introducing and calling method `enable_date_rex`

The test can fail in this way by running `pip3 install pytest-repeat; python3 -m pytest --count=2 tests/test_jsonextra.py::test_disable_rex`:

```
    def test_disable_rex():
>       assert jsonextra.loads('{"x": "1991-02-16"}') == {'x': datetime.date(1991, 2, 16)}
E       AssertionError: assert {'x': '1991-02-16'} == {'x': datetim...(1991, 2, 16)}
E         Differing items:
E         {'x': '1991-02-16'} != {'x': datetime.date(1991, 2, 16)}
E         Use -v to get the full diff
```

It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.
