### PR TITLE
Fix flaky test

### DIFF
--- a/jsonextra/json_extra.py
+++ b/jsonextra/json_extra.py
@@ -21,7 +21,12 @@ def disable_rex(rex):
     assert rex in _all_rex, f'Cannot disable rex which is not allowed! Available: {_all_rex}'
     globals()[rex] = None
 
+    
+def enable_rex(rex, val):
+    """Enables a regulax expresseion for matching"""
+    globals()[rex] = re.compile(val)
 
+    
 class ExtraEncoder(json.JSONEncoder):
 
     @staticmethod

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
 commit = True
-current_version = 0.3.2
+current_version = 0.3.3
 files = jsonextra/__init__.py
 tag = True
 tag_name = {new_version}

--- a/tests/test_jsonextra.py
+++ b/tests/test_jsonextra.py
@@ -157,6 +157,7 @@ def test_random_bytes():
 
 
 def test_disable_rex():
+    jsonextra.enable_rex('date_rex', r'^\d{4}\-[01]\d\-[0-3]\d$')
     assert jsonextra.loads('{"x": "1991-02-16"}') == {'x': datetime.date(1991, 2, 16)}
     jsonextra.disable_rex('date_rex')
     assert jsonextra.loads('{"x": "1991-02-16"}') == {'x': '1991-02-16'}


### PR DESCRIPTION
This PR aims to fix flaky test `tests/test_jsonextra.py::test_disable_rex`. It can run into errors when running for multiple times. The reason is that the date_rex is disabled but never recovered. The new enable function added can restore this issue.
The flakiness can be reproduced by
`pip install pytest-flakefinder`
`pytest --flake-finder --flake-runs=2 tests/test_jsonextra.py::test_disable_rex`